### PR TITLE
feat: embed cassette-tools in deck binary for standalone operation

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cassette-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cassette-tools",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cassette-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "CLI tool for creating and managing Cassette platform modules"
+build = "build.rs"
 
 # Set the binary name to "cassette"
 [[bin]]
@@ -14,6 +15,10 @@ path = "src/main.rs"
 name = "cassette_cli"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["deck"]
+deck = []
 
 [dependencies]
 cassette-tools = { path = "../cassette-tools" }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,60 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    // Only embed cassette-tools if we're building with the deck feature
+    if env::var("CARGO_FEATURE_DECK").is_ok() {
+        println!("cargo:rerun-if-changed=../cassette-tools/src/");
+        println!("cargo:rerun-if-changed=../cassette-tools/Cargo.toml");
+        
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let cassette_tools_dir = Path::new("../cassette-tools");
+        
+        // Check if cassette-tools exists
+        if !cassette_tools_dir.exists() {
+            panic!("cassette-tools directory not found at {:?}", cassette_tools_dir);
+        }
+        
+        // Create a directory to store cassette-tools source
+        let embedded_tools_dir = Path::new(&out_dir).join("embedded_cassette_tools");
+        if embedded_tools_dir.exists() {
+            fs::remove_dir_all(&embedded_tools_dir).ok();
+        }
+        fs::create_dir_all(&embedded_tools_dir).expect("Failed to create embedded tools directory");
+        
+        // Copy cassette-tools source files
+        println!("Embedding cassette-tools source...");
+        
+        // Copy Cargo.toml
+        fs::copy(
+            cassette_tools_dir.join("Cargo.toml"),
+            embedded_tools_dir.join("Cargo.toml")
+        ).expect("Failed to copy Cargo.toml");
+        
+        // Copy src directory
+        let src_dir = cassette_tools_dir.join("src");
+        let dest_src_dir = embedded_tools_dir.join("src");
+        fs::create_dir_all(&dest_src_dir).expect("Failed to create src directory");
+        
+        // Recursively copy all source files
+        copy_dir_all(&src_dir, &dest_src_dir).expect("Failed to copy source files");
+        
+        // Set environment variable with the path
+        println!("cargo:rustc-env=EMBEDDED_CASSETTE_TOOLS_DIR={}", embedded_tools_dir.display());
+    }
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(&entry.path(), &dst.join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}

--- a/cli/src/embedded_cassette_tools.rs
+++ b/cli/src/embedded_cassette_tools.rs
@@ -1,0 +1,15 @@
+/// Embedded cassette-tools path for deck functionality
+/// This module provides the path to the embedded cassette-tools source
+/// that gets copied into the build directory at compile time
+
+use std::path::Path;
+
+#[cfg(feature = "deck")]
+pub fn get_embedded_tools_dir() -> &'static Path {
+    Path::new(env!("EMBEDDED_CASSETTE_TOOLS_DIR"))
+}
+
+#[cfg(not(feature = "deck"))]
+pub fn get_embedded_tools_dir() -> &'static Path {
+    Path::new("")
+}

--- a/cli/src/templates/cassette_template.rs
+++ b/cli/src/templates/cassette_template.rs
@@ -82,7 +82,7 @@ struct Note {
 
 // Events embedded by CLI during build
 #[cfg(not(test))]
-const EVENTS: &str = include_str!("events.json");
+const EVENTS: &str = r###"{{events_json}}"###;
 
 #[cfg(test)]
 const EVENTS: &str = r#"[{


### PR DESCRIPTION
- Add build script to copy cassette-tools source during deck build
- Create embedded_cassette_tools module to access embedded tools
- Update deck to extract and reuse cassette-tools for all compilations
- Fix record command to use embedded tools when deck feature is enabled
- Bump version to 0.9.0

This allows deck and record commands to work without requiring cassette-tools in the working directory.

🤖 Generated with [Claude Code](https://claude.ai/code)